### PR TITLE
Scheduled ECS Task のサポート

### DIFF
--- a/lib/kumogata/template/events.rb
+++ b/lib/kumogata/template/events.rb
@@ -26,6 +26,10 @@ def _events_targets(args)
       Input target[:input] if target.key? :input
       InputPath target[:path] if target.key? :path
       RoleArn role unless role.empty?
+      EcsParameters _{
+        TaskCount target[:ecs_parameters][:task_count] if target[:ecs_parameters].key? :task_count
+        TaskDefinitionArn _ref_string("task_definition", target[:ecs_parameters], "ecs task definition", "arn")
+      } if target.key? :ecs_parameters
     }
   end
 end

--- a/lib/kumogata/template/events.rb
+++ b/lib/kumogata/template/events.rb
@@ -19,11 +19,13 @@ end
 
 def _events_targets(args)
   (args[:targets] || []).collect do |target|
+    role = _ref_attr_string("role", "Arn", target, "role")
     _{
       Arn _ref_attr_string("arn", "Arn", target)
       Id target[:id]
       Input target[:input] if target.key? :input
       InputPath target[:path] if target.key? :path
+      RoleArn role unless role.empty?
     }
   end
 end

--- a/test/events_test.rb
+++ b/test/events_test.rb
@@ -19,4 +19,51 @@ Test _events_targets({ targets: [ { arn: "test", id: "test" } ] })
     EOS
     assert_equal exp_template.chomp, act_template
   end
+
+  def test_events_target_scheduled_ecs_task
+    template = <<-EOS
+Test _events_targets({
+  schedule: "03 10 * * ? *",
+  targets: [
+    {
+      id: "test-id",
+      import_arn: "test",
+      ref_role: "test",
+      ecs_parameters: {
+        task_count: 1,
+        ref_task_definition: "test-task"
+      }
+    }
+  ]
+})
+    EOS
+    act_template = run_client_as_json(template)
+    exp_template = <<-EOS
+{
+  "Test": [
+    {
+      "Arn": {
+        "Fn::ImportValue": {
+          "Fn::Sub": "test"
+        }
+      },
+      "Id": "test-id",
+      "RoleArn": {
+        "Fn::GetAtt": [
+          "TestRole",
+          "Arn"
+        ]
+      },
+      "EcsParameters": {
+        "TaskCount": "1",
+        "TaskDefinitionArn": {
+          "Ref": "TestTaskEcsTaskDefinition"
+        }
+      }
+    }
+  ]
+}
+    EOS
+    assert_equal exp_template.chomp, act_template
+  end
 end


### PR DESCRIPTION
ECS Task を実行する AWS::Events::Rule の定義に必要な RoleArn と EcsParameters を追加しました。

ref.

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html
- https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutTargets.html

---

```
$ bundle ex ruby -I test test/events_test.rb
Run options: --seed 53757

# Running:

..

Finished in 0.017128s, 116.7679 runs/s, 116.7679 assertions/s.

2 runs, 2 assertions, 0 failures, 0 errors, 0 skip
```